### PR TITLE
Fixed a bug in the download and upload

### DIFF
--- a/Source/Suin/FTPClient/FTPClient.php
+++ b/Source/Suin/FTPClient/FTPClient.php
@@ -370,6 +370,7 @@ class Suin_FTPClient_FTPClient implements Suin_FTPClient_FTPClientInterface,
 			fwrite($localFilePointer, fread($dataConnection, 10240), 10240);
 		}
 
+		$response = $this->_getResponse();
 
 		return true;
 	}
@@ -433,6 +434,8 @@ class Suin_FTPClient_FTPClient implements Suin_FTPClient_FTPClientInterface,
 		{
 			fwrite($dataConnection, fread($localFilePointer, 10240), 10240);
 		}
+
+		$response = $this->_getResponse();
 
 		return true;
 	}


### PR DESCRIPTION
I added $this->_getResponse() after the download and upload. Was having an issue where I was getting empty files and noticed that it was not waiting for the download complete message to come across the stream.
You might want to build a list of failed uploads/downloads or something but this got it working so that I could use it.
