### PR TITLE
Fix for upload/uploadString method on slow connection

### DIFF
--- a/Source/Suin/FTPClient/FTPClient.php
+++ b/Source/Suin/FTPClient/FTPClient.php
@@ -519,6 +519,13 @@ class Suin_FTPClient_FTPClient implements Suin_FTPClient_FTPClientInterface,
 		{
 			fwrite($dataConnection, fread($localFilePointer, 10240), 10240);
 		}
+		
+		$this->_closePassv($dataConnection);
+
+		$response = $this->_getResponse();
+		if ($response['code'] != 226) {
+			return false;
+		}
 
 		return true;
 	}
@@ -566,7 +573,14 @@ class Suin_FTPClient_FTPClient implements Suin_FTPClient_FTPClientInterface,
 		}
 
 		fwrite($dataConnection, $content);
+		
+		$this->_closePassv($dataConnection);
 
+		$response = $this->_getResponse();
+		if ($response['code'] != 226) {
+			return false;
+		}
+		
 		return true;
 	}
 


### PR DESCRIPTION
There was a problem when I tried to upload a heavy file on a slow connection.
The file could be transferred incompletely.
According to FTP specifications:
"If we connect to the server the server will respond with 150 and if the connection is closed from our side the server assumes that the file is transmitted completely and will issue a 226 line."
we have to wait for 226 response code on command channel to be sure that all data is written.
In my case if I close both connections (exit php script) just after all fwrite`s on data channel are completed, I get the file incompletely written on ftp (looks like ftp server stops receiving data after command channel is closed). After the fix everything works ok for me.
