### PR TITLE
Fixed namespaces (underscore)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Suin\\FTPClient": "Source"
+            "Suin_FTPClient_": "Source"
         }
     }
 }


### PR DESCRIPTION
- Namespace separator for classes use underscore
- Prefix for namespace requires separator after `Suin_FTPClient`
